### PR TITLE
fix: Only push to PyPI when creating a new release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      needs_release: ${{ steps.build.outputs.needs_release }}
 
     steps:
 
@@ -47,7 +49,8 @@ jobs:
         python -m pip install --upgrade pipenv wheel build
         PIPENV_PIPFILE=scripts/changes/Pipfile pipenv install
 
-    - name: Build the package
+    - id: build
+      name: Build the package
       run: scripts/build.sh
 
     - name: Store the distribution packages
@@ -63,7 +66,7 @@ jobs:
       if: ${{ github.ref == 'refs/heads/main' }}
 
   publish-to-pypi:
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    if: ${{ (github.ref == 'refs/heads/main') && (needs.build.outputs.build.needs_release) }}
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change infers whether we've made a release by checking whether a release is required as part of the build and assumes a successful build job resulted in a successful release.