### PR TITLE
fix: Correct the GitHub Actions `needs_release` output reference

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
       if: ${{ github.ref == 'refs/heads/main' }}
 
   publish-to-pypi:
-    if: ${{ (github.ref == 'refs/heads/main') && (needs.build.outputs.build.needs_release) }}
+    if: ${{ (github.ref == 'refs/heads/main') && (needs.build.outputs.needs_release) }}
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
This incorrect reference was blocking pushes to PyPI.