### PR TITLE
ci: Fix boolean conversion issues when gating PyPI pushes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
       if: ${{ github.ref == 'refs/heads/main' }}
 
   publish-to-pypi:
-    if: ${{ (github.ref == 'refs/heads/main') && (needs.build.outputs.needs_release) }}
+    if: ${{ (github.ref == 'refs/heads/main') && (needs.build.outputs.needs_release == 'true') }}
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Unfortunately it looks like GitHub Actions interpret the 'true' returned from our build step as a string so we need to do a string comparison otherwise it will always evaluate to true.